### PR TITLE
Add stylist listing web page

### DIFF
--- a/stylists.html
+++ b/stylists.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Supercuts Stylists - New England</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="font-sans text-gray-800 p-6">
+  <h1 class="text-2xl font-bold mb-6">Supercuts Stylists in New England</h1>
+  <div id="stylists" class="space-y-6"></div>
+  <script src="stylists.js"></script>
+</body>
+</html>

--- a/stylists.js
+++ b/stylists.js
@@ -1,0 +1,42 @@
+const stylistsByLocation = {
+  "Boston, MA": [
+    {name: "Alex B.", mention: "Excellent reviews for modern men's styles", tags: ["men", "coloring"]},
+    {name: "Sara K.", mention: "Known for vibrant coloring work", tags: ["women", "coloring", "waxing"]}
+  ],
+  "Cambridge, MA": [
+    {name: "Jamie L.", mention: "Great with kids and quick cuts", tags: ["men", "women", "kids"]}
+  ],
+  "Providence, RI": [
+    {name: "Morgan P.", mention: "Skilled with beard trims", tags: ["men", "waxing"]}
+  ],
+  "Hartford, CT": [
+    {name: "Taylor R.", mention: "Versatile stylist for all ages", tags: ["men", "women", "kids"]}
+  ],
+  "Portland, ME": [
+    {name: "Casey D.", mention: "Specializes in color and highlights", tags: ["women", "coloring"]}
+  ]
+};
+
+document.addEventListener('DOMContentLoaded', function() {
+  const container = document.getElementById('stylists');
+
+  for (const [location, stylists] of Object.entries(stylistsByLocation)) {
+    const locDiv = document.createElement('div');
+
+    const heading = document.createElement('h2');
+    heading.textContent = location;
+    heading.className = 'text-xl font-semibold mb-2';
+    locDiv.appendChild(heading);
+
+    const list = document.createElement('ul');
+    list.className = 'space-y-1';
+    stylists.forEach(s => {
+      const item = document.createElement('li');
+      const tags = s.tags.map(tag => `<span class="px-2 py-1 bg-gray-200 rounded text-sm">${tag}</span>`).join(' ');
+      item.innerHTML = `<span class="font-medium">${s.name}</span> - ${s.mention}<div class="mt-1">${tags}</div>`;
+      list.appendChild(item);
+    });
+    locDiv.appendChild(list);
+    container.appendChild(locDiv);
+  }
+});


### PR DESCRIPTION
## Summary
- add a simple Supercuts stylist listing web page (`stylists.html`)
- implement dataset and rendering logic in `stylists.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687da7a525a883208a52e40d5f4f8615